### PR TITLE
fix: support UCCSD and correct Hamiltonian expectation value computation

### DIFF
--- a/src/mqss/pennylane_adapter/device.py
+++ b/src/mqss/pennylane_adapter/device.py
@@ -76,6 +76,15 @@ class MQSSPennylaneDevice(Device):
         adapter = MQSSPennylaneAdapter(token=self.TOKEN, url=MQSS_URL)
         backend = adapter.get_backend(self.BACKENDS)
         is_hamiltonian = False
+        decomposed = []
+        for tape in circuits:
+            [decomposed_tape], _ = qml.transforms.decompose(
+                tape,
+                gate_set=supports_operation,
+            )
+            decomposed.append(decomposed_tape)
+        circuits = decomposed
+        '''
         for tape in circuits:
             try:
                 self.validate_tape_operations(tape)
@@ -83,6 +92,7 @@ class MQSSPennylaneDevice(Device):
                 print(
                     f"Skipping tape due to error in validating operations, original exception: {e}"
                 )
+        '''
 
         if isinstance(tape.measurements[0], qml.measurements.ExpectationMP):
             if isinstance(tape.measurements[0].obs, qml.ops.op_math.LinearCombination):
@@ -192,7 +202,7 @@ class MQSSPennylaneDevice(Device):
                 )
                 if is_hamiltonian:
                     final_expectation += (
-                        expectation * circuits[0]._measurements[0].obs.scalar
+                        expectation * circuits[cdx]._measurements[0].obs.scalar
                     )
                 else:
                     final_expectation += expectation
@@ -220,18 +230,17 @@ class MQSSPennylaneDevice(Device):
         for idx, value in enumerate(count):
             try:
                 bitstring = int2bit(idx, num_qubits)
-                for bdx, bit in enumerate(bitstring):
-                    weighted_count = value
-                    if bdx in measured_qubits:
-                        if bit == "1":
-                            weighted_count *= -1
-                        expectation += weighted_count
-                expectation /= shots
+                eigenvalue = 1.0
+                for bdx in measured_qubits:
+                    if bitstring[bdx] == "1":
+                        eigenvalue *= -1
+                expectation += value * eigenvalue
 
             except ValueError as e:
                 raise ValueError(
                     f"Number of wires must be defined for expectation value calculation, original error: {e}"
                 )
+        expectation /= shots
         return expectation
 
     def append_measurement_gates(


### PR DESCRIPTION
## Summary

### Feature Added

Support for computing expectation values from quantum circuits generated via PennyLane’s chemistry module.

The core issue is in `device.py` and `utils.py` :  `validate_tape_operations(tape)` (in device.py) iterates over all operations in the tape and checks them against `operations` frozenset in utils.py.  The frozenset only includes basic gates like PauliX, PauliY, PauliZ, Hadamard, CNOT, CZ, RX, RY, and RZ. **UCCSD** uses `FermionicSingleExcitation` and `FermionicDoubleExcitation` - these aren't in the frozenset, so validation fails.

The solution proposed here: decompose the tape into supported gates before submission using PennyLane's decompose transform, which will break down the UCCSD operations into the basic gate set the backend actually supports.

### Few Bugs Found (device.py)

In `get_expectation_value` function  the expectation value should be:

$$  
\mathbb{E} = \frac{1}{\text{shots}} \sum_{i} \big( \text{count}_i \cdot w_i \big)  
$$

But currently the code add `weighted_count` ($w_i$) inside an inner loop, meaning instead of multiplying contributions, it is accumulating them.

There are also contributions coming from  the line  `expectation /= shots` also inside the `for idx` loop.  It will create contributions like: 

$$  
\text{expectation} = \frac{1}{\text{shots}} \left( \frac{c_1}{\text{shots}} + c_2 \right)  
$$

To solve this we need to move `expectation /= shots` out of the inner loop. 

Finally in in `calculate_measurement_type` `circuits[0]` is used for all Hamiltonian terms instead of `circuits[cdx]`, so all terms are multiplied by the coefficient of the _first_ term only.