### PR TITLE
[Feature]: Support for collection of Observables

### DIFF
--- a/docs/user_guide/getting_started.md
+++ b/docs/user_guide/getting_started.md
@@ -11,6 +11,10 @@ pip install mqss-pennylane-adapter
 
 ## 🚀 Job Submission with different measurement types
 MQSS PennyLane Provider has support for most of the native PennyLane features. For instance, you can define a quantum circuit using PennyLane quantum gates, and decorate the method with the MQSSPennylaneDevice object. Parametric gates can also be used. 
+
+### Expectation Values using Pauli Observables
+It is possible to define any Pauli word using the keywords  `qml.PauliX`, `qml.PauliY` or `qml.PauliZ` and highlight which qubit each Pauli acts on, to calculate the expectation value with respect to that observable, same way it is done with PennyLane default devices.
+
 ```python
 import pennylane as qml
 from pennylane import numpy as np
@@ -37,7 +41,10 @@ def quantum_function_expval(x, y):
 
 params = [np.pi / 3, np.pi / 17]
 result = quantum_function_expval(*params)
+
 ```
+### Expectation Values using Hamiltonians
+
 Furthermore, you can define a Hamiltonian object within PennyLane, and calculate the expectation value with respect to that Hamiltonian. For these cases, Pennylane Provider simply creates a batch job for each term in the Hamiltonian, to calculate the expectation value.
 
 ```python
@@ -68,7 +75,7 @@ obs = [
 hamiltonian = qml.Hamiltonian(coeffs, obs)
 result = quantum_function_hamiltonian_expval(*params, hamiltonian)
 ```
-
+### Probabilities (Counts)
 If you are just interested in accessing the counts (or probabilities), you can also use
 
 ```python
@@ -86,6 +93,37 @@ def circuit(
     qml.CNOT(wires=[0, 1])
     qml.RY(y, wires=1)
     return qml.probs(qml.probs(wires=[0, 1]))
+```
+
+# List of Observables
+
+In specific routines, you might require multiple measurement results based on a different combination of Pauli words. Different operators might also act on the same qubit. The return statement has to be defined as a list of expectation value combinations as follows:
+```python
+observables = [qml.PauliZ(0), qml.PauliX(1), qml.PauliZ(2) @ qml.PauliZ(3)]
+
+@qml.qnode(dev, shots=1024)
+def quantum_function_expval(x, y):
+    """
+    Defines an arbitrary mock quantum circuit for testing purposes, with an expectation value measurement
+
+    :param x: The parameter `x` represents the angle for the rotation gate
+    `RZ` applied on the qubit at wire 0
+    :param y: The parameter `y` represents the angle parameter for
+    the rotation gate `RY` at wire 1.
+    """
+    qml.RZ(x, wires=0)
+    qml.CNOT(wires=[0, 1])
+    qml.RY(y, wires=1)
+    qml.CNOT(wires=[1, 0])
+    qml.RX(x, wires=1)
+    return [qml.expval(obs) for obs in observables]
+```
+
+In such cases, the output is also a list, corresponding to the expectation value of each term. For instance, for the case above, the output is as follows:
+
+**Output:**
+```text
+[tensor(0.75976562, requires_grad=True), tensor(0.0625, requires_grad=True), tensor(0.96679688, requires_grad=True)]
 ```
 
 With the latest release (1.2.0), it is also possible to run high level PennyLane native quantum operations using the MQSS backends, such as `FermionicDoubleExcitation`:

--- a/docs/user_guide/getting_started.md
+++ b/docs/user_guide/getting_started.md
@@ -95,7 +95,7 @@ def circuit(
     return qml.probs(qml.probs(wires=[0, 1]))
 ```
 
-# List of Observables
+### List of Observables
 
 In specific routines, you might require multiple measurement results based on a different combination of Pauli words. Different operators might also act on the same qubit. The return statement has to be defined as a list of expectation value combinations as follows:
 ```python
@@ -126,7 +126,7 @@ In such cases, the output is also a list, corresponding to the expectation value
 [tensor(0.75976562, requires_grad=True), tensor(0.0625, requires_grad=True), tensor(0.96679688, requires_grad=True)]
 ```
 
-With the latest release (1.2.0), it is also possible to run high level PennyLane native quantum operations using the MQSS backends, such as `FermionicDoubleExcitation`:
+With the latest release (1.2.1), it is also possible to run high level PennyLane native quantum operations using the MQSS backends, such as `FermionicDoubleExcitation`:
 ```python
 def build_h2_problem():
     symbols = ["H", "H"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mqss-pennylane-adapter"
-version = "1.2.0"
+version = "1.2.1"
 description = "A Pennylane Adapter package for the Munich Quantum Software Stack."
 authors = [{ name = "mqss", email = "mqss@munich-quantum-valley.de" }]
 readme = "README.md"

--- a/src/mqss/pennylane_adapter/device.py
+++ b/src/mqss/pennylane_adapter/device.py
@@ -20,6 +20,7 @@ class MeasurementType(Enum):
     SAMPLE = auto()
     STATE = auto()
     UNKNOWN = auto()
+    MULTIPLE_EXPVAL = auto()
 
 
 class MQSSPennylaneDevice(Device):
@@ -65,6 +66,7 @@ class MQSSPennylaneDevice(Device):
         self.BACKENDS = backends
         self.measurement_type: MeasurementType = MeasurementType.UNKNOWN
         self.batch_circuits: bool = False
+        self.is_multiple_obs: bool = False
         self._legacy_shots = shots
 
     def determine_measurement_type(
@@ -80,6 +82,8 @@ class MQSSPennylaneDevice(Device):
         """
         if not circuit.measurements:
             return MeasurementType.UNKNOWN
+        if len(circuit.measurements) > 1:
+            return MeasurementType.MULTIPLE_EXPVAL
         measurement = circuit.measurements[0]
         if isinstance(measurement, qml.measurements.ProbabilityMP):
             return MeasurementType.PROBS
@@ -135,7 +139,10 @@ class MQSSPennylaneDevice(Device):
         if (
             self.measurement_type == MeasurementType.EXPVAL_HAMILTONIAN
             or self.measurement_type == MeasurementType.EXPVAL
+            or self.measurement_type == MeasurementType.MULTIPLE_EXPVAL
         ):
+            if self.measurement_type == MeasurementType.EXPVAL_HAMILTONIAN:
+                self.is_multiple_obs = True
             if isinstance(
                 circuit.measurements[0].obs, qml.ops.op_math.LinearCombination
             ):
@@ -168,6 +175,7 @@ class MQSSPennylaneDevice(Device):
         if (
             self.measurement_type != MeasurementType.EXPVAL_HAMILTONIAN
             and self.measurement_type != MeasurementType.EXPVAL
+            and self.measurement_type != MeasurementType.MULTIPLE_EXPVAL
         ):
             return circuit
 
@@ -175,7 +183,10 @@ class MQSSPennylaneDevice(Device):
         if is_hamiltonian:
             observables = circuit.measurements[0].obs
         else:
-            observables = [circuit.measurements[0].obs]
+            if self.measurement_type == MeasurementType.MULTIPLE_EXPVAL:
+                observables = [measurement.obs for measurement in circuit.measurements]
+            else:
+                observables = [circuit.measurements[0].obs]
         for obs in observables:
             modified_circuit = self.append_measurement_gates(
                 copy.deepcopy(circuit), obs, is_hamiltonian
@@ -275,6 +286,29 @@ class MQSSPennylaneDevice(Device):
                 else:
                     final_expectation += expectation
             return [final_expectation]
+        elif self.measurement_type == MeasurementType.MULTIPLE_EXPVAL:
+            final_expectation = []
+            for cdx, count in enumerate(counts):
+
+                measurement = circuits[cdx].measurements[cdx]
+                observable = getattr(measurement, "obs", None)
+
+                base_observable = getattr(observable, "base", observable)
+                if hasattr(base_observable, "operands"):
+                    obs_terms = base_observable.operands
+                else:
+                    obs_terms = [base_observable]
+
+                measured_qubits = [op.wires.labels[0] for op in obs_terms]
+
+                num_qubits = len(circuits[cdx].wires)
+
+                expectation = self.get_expectation_value(
+                    count, measured_qubits, num_qubits, shots
+                )
+
+                final_expectation.append(expectation)
+            return [final_expectation]
         elif self.measurement_type == MeasurementType.SAMPLE:
             raise NotImplementedError
         elif self.measurement_type == MeasurementType.STATE:
@@ -284,7 +318,7 @@ class MQSSPennylaneDevice(Device):
 
     def get_expectation_value(
         self,
-        count: list[float],
+        count: dict[str, int] | list[dict[str, int]],
         measured_qubits: tuple[int],
         num_qubits: int,
         shots: int,
@@ -358,7 +392,7 @@ class MQSSPennylaneDevice(Device):
 
     def fetch_counts(
         self, counts: dict[str, int] | list[dict[str, int]], shots: int
-    ) -> list[dict[str, int] | list[dict[str, int]]]:
+    ) -> dict[str, int] | list[dict[str, int]]:
         """Given a dictionary representing the measurements, return the probability distribution as an array
 
         Args:

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -46,3 +46,18 @@ def obs(request):
 )
 def hamiltonian_data(request):
     return request.param
+
+
+@pytest.fixture(
+    params=[
+        [
+            [qml.PauliZ(0), qml.PauliX(1), qml.PauliZ(2), qml.PauliZ(3)],
+            [qml.PauliZ(0), qml.PauliX(1), qml.PauliZ(2) @ qml.PauliZ(3)],
+            [qml.PauliZ(0) @ qml.PauliX(1), qml.PauliZ(2), qml.PauliZ(3)],
+            [qml.PauliZ(0) @ qml.PauliX(1), qml.PauliZ(2) @ qml.PauliZ(3)],
+            [qml.PauliZ(0) @ qml.PauliX(1) @ qml.PauliZ(2) @ qml.PauliZ(3)],
+        ]
+    ]
+)
+def list_obs(request):
+    return request.param

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -50,13 +50,11 @@ def hamiltonian_data(request):
 
 @pytest.fixture(
     params=[
-        [
-            [qml.PauliZ(0), qml.PauliX(1), qml.PauliZ(2), qml.PauliZ(3)],
-            [qml.PauliZ(0), qml.PauliX(1), qml.PauliZ(2) @ qml.PauliZ(3)],
-            [qml.PauliZ(0) @ qml.PauliX(1), qml.PauliZ(2), qml.PauliZ(3)],
-            [qml.PauliZ(0) @ qml.PauliX(1), qml.PauliZ(2) @ qml.PauliZ(3)],
-            [qml.PauliZ(0) @ qml.PauliX(1) @ qml.PauliZ(2) @ qml.PauliZ(3)],
-        ]
+        [qml.PauliZ(0), qml.PauliX(1), qml.PauliZ(2), qml.PauliZ(3)],
+        [qml.PauliZ(0), qml.PauliX(1), qml.PauliZ(2) @ qml.PauliZ(3)],
+        [qml.PauliZ(0) @ qml.PauliX(1), qml.PauliZ(2), qml.PauliZ(3)],
+        [qml.PauliZ(0) @ qml.PauliX(1), qml.PauliZ(2) @ qml.PauliZ(3)],
+        [qml.PauliZ(0) @ qml.PauliX(1) @ qml.PauliZ(2) @ qml.PauliZ(3)],
     ]
 )
 def list_obs(request):

--- a/test/test_backend_live.py
+++ b/test/test_backend_live.py
@@ -7,6 +7,7 @@ from pennylane import numpy as np
 from .pennylane_adapter_tests_base import TestPennylaneAdapter
 
 dev = MQSSPennylaneDevice(wires=2, token=MQSS_TOKEN, backends=MQSS_BACKENDS)
+dev_multiple = MQSSPennylaneDevice(wires=10, token=MQSS_TOKEN, backends=MQSS_BACKENDS)
 dev_simulator = qml.device("default.qubit", wires=2)
 dev_hamiltonian = MQSSPennylaneDevice(wires=2, token=MQSS_TOKEN, backends=MQSS_BACKENDS)
 dev_hamiltonian_simulator = qml.device("default.qubit", wires=2)
@@ -228,3 +229,28 @@ class TestPennylaneLiveJobs(TestPennylaneAdapter):
         assert len(result) == (2**num_qubits)
         assert abs(sum(result) - 1) <= 1e-6
         assert all(0 <= p <= 1 for p in result)
+
+    def test_multiple_expvals(
+        self, list_obs: list[qml.ops.qubit.non_parametric_ops], params: list[float]
+    ):
+        """Test that we can get multiple expectation values back from the device"""
+
+        @qml.qnode(dev_multiple, shots=1024)
+        def quantum_function_expval(x, y):
+            """
+            Defines an arbitrary mock quantum circuit for testing purposes, with an expectation value measurement
+
+            :param x: The parameter `x` represents the angle for the rotation gate
+            `RZ` applied on the qubit at wire 0
+            :param y: The parameter `y` represents the angle parameter for
+            the rotation gate `RY` at wire 1.
+            """
+            qml.RZ(x, wires=0)
+            qml.CNOT(wires=[0, 1])
+            qml.RY(y, wires=1)
+            qml.CNOT(wires=[1, 0])
+            qml.RX(x, wires=1)
+            return [qml.expval(obs) for obs in list_obs]
+
+        result = quantum_function_expval(*params)
+        assert len(result) == len(list_obs)

--- a/test/test_backend_live.py
+++ b/test/test_backend_live.py
@@ -7,7 +7,7 @@ from pennylane import numpy as np
 from .pennylane_adapter_tests_base import TestPennylaneAdapter
 
 dev = MQSSPennylaneDevice(wires=2, token=MQSS_TOKEN, backends=MQSS_BACKENDS)
-dev_multiple = MQSSPennylaneDevice(wires=10, token=MQSS_TOKEN, backends=MQSS_BACKENDS)
+dev_multiple = MQSSPennylaneDevice(wires=4, token=MQSS_TOKEN, backends=MQSS_BACKENDS)
 dev_simulator = qml.device("default.qubit", wires=2)
 dev_hamiltonian = MQSSPennylaneDevice(wires=2, token=MQSS_TOKEN, backends=MQSS_BACKENDS)
 dev_hamiltonian_simulator = qml.device("default.qubit", wires=2)
@@ -236,7 +236,7 @@ class TestPennylaneLiveJobs(TestPennylaneAdapter):
         """Test that we can get multiple expectation values back from the device"""
 
         @qml.qnode(dev_multiple, shots=1024)
-        def quantum_function_expval(x, y):
+        def quantum_function_expval_multiple(x, y):
             """
             Defines an arbitrary mock quantum circuit for testing purposes, with an expectation value measurement
 
@@ -252,5 +252,5 @@ class TestPennylaneLiveJobs(TestPennylaneAdapter):
             qml.RX(x, wires=1)
             return [qml.expval(obs) for obs in list_obs]
 
-        result = quantum_function_expval(*params)
+        result = quantum_function_expval_multiple(*params)
         assert len(result) == len(list_obs)

--- a/uv.lock
+++ b/uv.lock
@@ -468,7 +468,7 @@ wheels = [
 
 [[package]]
 name = "mqss-pennylane-adapter"
-version = "1.2.0"
+version = "1.2.1"
 source = { editable = "." }
 dependencies = [
     { name = "mqp-client" },


### PR DESCRIPTION
Fixes #21 

Now, the tool enables users to measure multiple observables and get multiple expectation value outputs as a collection. 

```
observables = [qml.PauliZ(0), qml.PauliX(1), qml.PauliZ(2) @ qml.PauliZ(3)]
@qml.qnode(dev, shots=1024)
def quantum_function_expval(x, y):
        qml.RZ(x, wires=0)
        qml.CNOT(wires=[0, 1])
        qml.RY(y, wires=1)
        return [qml.expval(obs) for obs in observables]
```
Then, the output looks like: 
`[tensor(0.75976562, requires_grad=True), tensor(0.0625, requires_grad=True), tensor(0.96679688, requires_grad=True)]`

Note that each elements in the observable list can also act on the same qubit repeatedly, and be non-commuting operations with the other elements, in which case there will be more circuit submissions, as many as the different terms inside the observable collection.