### PR TITLE
[Feature]: Improve batching logic for commuting terms in Hamiltonian

### DIFF
--- a/src/mqss/pennylane_adapter/device.py
+++ b/src/mqss/pennylane_adapter/device.py
@@ -47,6 +47,7 @@ class MQSSPennylaneDevice(Device):
         backends: str,
         wires=None,
         shots=1024,
+        use_commuting_measurement_grouping=True,
         seed=None,
         supports_derivatives=False,
     ):
@@ -59,6 +60,7 @@ class MQSSPennylaneDevice(Device):
             shots (int, optional): Legacy attribute for number of shots. Now, shots attribute is expected at the QNode level, but this attribute stays as a legacy fallback option. Defaults to 1024.
             seed (int, optional): Defaults to None.
             supports_derivatives (bool, optional): Boolean flag for autograd support. Defaults to False.
+            use_commuting_measurement_grouping (bool, optional): Boolean flag to indicate whether to use commuting measurement grouping for Hamiltonian expectation value calculation. Defaults to True.
         """
         super().__init__(wires=wires)
 
@@ -68,6 +70,7 @@ class MQSSPennylaneDevice(Device):
         self.batch_circuits: bool = False
         self.is_multiple_obs: bool = False
         self._legacy_shots = shots
+        self.use_commuting_measurement_grouping = use_commuting_measurement_grouping
 
     def determine_measurement_type(
         self, circuit: QuantumScriptOrBatch
@@ -181,18 +184,44 @@ class MQSSPennylaneDevice(Device):
 
         batched_circuits = []
         if is_hamiltonian:
-            observables = circuit.measurements[0].obs
+            if self.use_commuting_measurement_grouping:
+                hamiltonian = circuit.measurements[0].obs
+                coeffs = hamiltonian.coeffs
+                observables = hamiltonian.ops
+
+                groups = qml.pauli.group_observables(observables, grouping_type="qwc")
+                self.grouped_coeffs = []
+                self.grouped_observables = groups
+
+                for group in groups:
+                    group_coeffs = []
+                    for obs in group:
+                        idx = observables.index(obs)
+                        group_coeffs.append(coeffs[idx])
+                    self.grouped_coeffs.append(group_coeffs)
+                
+                for group in groups:
+                    modified_circuit = copy.deepcopy(circuit)
+                    for obs in group:
+                        modified_circuit = self.append_measurement_gates(
+                            modified_circuit, obs, is_hamiltonian
+                        )
+                    batched_circuits.append(modified_circuit)
+            else:
+                observables = circuit.measurements[0].obs
         else:
             if self.measurement_type == MeasurementType.MULTIPLE_EXPVAL:
                 observables = [measurement.obs for measurement in circuit.measurements]
             else:
                 observables = [circuit.measurements[0].obs]
-        for obs in observables:
-            modified_circuit = self.append_measurement_gates(
-                copy.deepcopy(circuit), obs, is_hamiltonian
-            )
-            # modified_circuit.measurements = [qml.expval(obs)]
-            batched_circuits.append(modified_circuit)
+
+        if not (is_hamiltonian and self.use_commuting_measurement_grouping):
+            for obs in observables:
+                modified_circuit = self.append_measurement_gates(
+                    copy.deepcopy(circuit), obs, is_hamiltonian
+                )
+                # modified_circuit.measurements = [qml.expval(obs)]
+                batched_circuits.append(modified_circuit)
         if len(batched_circuits) > 1:
             self.batch_circuits = True
 
@@ -241,8 +270,25 @@ class MQSSPennylaneDevice(Device):
             self.measurement_type == MeasurementType.EXPVAL
             or self.measurement_type == MeasurementType.EXPVAL_HAMILTONIAN
         ):
-
             final_expectation = 0
+            if is_hamiltonian and self.use_commuting_measurement_grouping:
+                for cdx, count in enumerate(counts):
+                    group = self.grouped_observables[cdx]
+                    coeffs = self.grouped_coeffs[cdx]
+
+                    num_qubits = len(circuits[0].wires)
+
+                    for obs, coeff in zip(group, coeffs):
+                        if hasattr(obs, "operands"):
+                            measured_qubits = [op.wires.labels[0] for op in obs.operands]
+                        else:
+                            measured_qubits = [obs.wires.labels[0]]
+                        expectation = self.get_expectation_value(
+                            count, measured_qubits, num_qubits, shots
+                        )
+                        final_expectation += expectation * coeff
+                return [final_expectation]
+            
             for cdx, count in enumerate(counts):
                 if self.batch_circuits:
                     measurement = circuits[0].measurements[0]
@@ -367,7 +413,7 @@ class MQSSPennylaneDevice(Device):
             QuantumScriptOrBatch: Pennylane circuit
         """
         try:
-            if is_hamiltonian:
+            if is_hamiltonian and not self.use_commuting_measurement_grouping:
                 observables = obs.base
             else:
                 observables = obs

--- a/src/mqss/pennylane_adapter/device.py
+++ b/src/mqss/pennylane_adapter/device.py
@@ -276,19 +276,22 @@ class MQSSPennylaneDevice(Device):
                     group = self.grouped_observables[cdx]
                     coeffs = self.grouped_coeffs[cdx]
 
-                    num_qubits = len(circuits[0].wires)
+                    if self.batch_circuits:
+                        num_qubits = len(circuits[0].wires)
+                    else:
+                        num_qubits = len(circuits.wires)
 
                     for obs, coeff in zip(group, coeffs):
                         if hasattr(obs, "operands"):
-                            measured_qubits = [op.wires.labels[0] for op in obs.operands]
+                            measured_qubits = tuple(op.wires.labels[0] for op in obs.operands)
                         else:
-                            measured_qubits = [obs.wires.labels[0]]
+                            measured_qubits = tuple([obs.wires.labels[0]])
                         expectation = self.get_expectation_value(
                             count, measured_qubits, num_qubits, shots
                         )
                         final_expectation += expectation * coeff
                 return [final_expectation]
-            
+
             for cdx, count in enumerate(counts):
                 if self.batch_circuits:
                     measurement = circuits[0].measurements[0]

--- a/src/mqss/pennylane_adapter/device.py
+++ b/src/mqss/pennylane_adapter/device.py
@@ -161,7 +161,24 @@ class MQSSPennylaneDevice(Device):
             result, circuit, shots, is_hamiltonian
         )
         return measurement
+    
+    def _merge_qwc_group(self, group):
+        """
+        Merge a qubit-wise-commuting (QWC) group of Pauli observables into a
+        single observable with exactly one Pauli operator per wire.
+        """
+        wire_to_op = {}
+        for obs in group:
+            ops = obs.operands if hasattr(obs, "operands") else [obs]
+            for op in ops:
+                wire = op.wires[0]
+                wire_to_op[wire] = op
 
+        merged_ops = list(wire_to_op.values())
+        if len(merged_ops) == 1:
+            return merged_ops[0]
+        return qml.prod(*merged_ops)  
+    
     def create_batch_circuits_for_hamiltonians(
         self, circuit: QuantumScriptOrBatch, is_hamiltonian: bool
     ) -> Union[list[QuantumScriptOrBatch], QuantumScriptOrBatch]:
@@ -202,11 +219,18 @@ class MQSSPennylaneDevice(Device):
                 
                 for group in groups:
                     modified_circuit = copy.deepcopy(circuit)
-                    for obs in group:
-                        modified_circuit = self.append_measurement_gates(
-                            modified_circuit, obs, is_hamiltonian
-                        )
+                    merged_obs = self._merge_qwc_group(group)
+                    modified_circuit = self.append_measurement_gates(
+                        modified_circuit, merged_obs, is_hamiltonian
+                    )
                     batched_circuits.append(modified_circuit)
+
+                if len(batched_circuits) > 1:
+                    self.batch_circuits = True
+                else:
+                    batched_circuits = batched_circuits[0]
+                    
+                return batched_circuits
             else:
                 observables = circuit.measurements[0].obs
         else:
@@ -215,13 +239,12 @@ class MQSSPennylaneDevice(Device):
             else:
                 observables = [circuit.measurements[0].obs]
 
-        if not (is_hamiltonian and self.use_commuting_measurement_grouping):
-            for obs in observables:
-                modified_circuit = self.append_measurement_gates(
-                    copy.deepcopy(circuit), obs, is_hamiltonian
-                )
-                # modified_circuit.measurements = [qml.expval(obs)]
-                batched_circuits.append(modified_circuit)
+        for obs in observables:
+            modified_circuit = self.append_measurement_gates(
+                copy.deepcopy(circuit), obs, is_hamiltonian
+            )
+            # modified_circuit.measurements = [qml.expval(obs)]
+            batched_circuits.append(modified_circuit)
         if len(batched_circuits) > 1:
             self.batch_circuits = True
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -42,6 +42,14 @@ def obs(request):
             [1.5],
             [qml.PauliZ(0)],
         ),
+        (
+            [-0.5, -0.2, -0.2],
+            [
+                qml.PauliZ(0) @ qml.PauliZ(1),
+                qml.PauliX(0),
+                qml.PauliX(1),
+            ],
+        ),
     ]
 )
 def hamiltonian_data(request):

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -43,6 +43,10 @@ def obs(request):
             [qml.PauliZ(0)],
         ),
         (
+            [1.2, 0.3],
+            [qml.PauliX(0) @ qml.PauliX(1), qml.PauliX(0)],
+        ),
+        (
             [-0.5, -0.2, -0.2],
             [
                 qml.PauliZ(0) @ qml.PauliZ(1),

--- a/test/test_backend_live.py
+++ b/test/test_backend_live.py
@@ -9,8 +9,9 @@ from .pennylane_adapter_tests_base import TestPennylaneAdapter
 dev = MQSSPennylaneDevice(wires=2, token=MQSS_TOKEN, backends=MQSS_BACKENDS)
 dev_multiple = MQSSPennylaneDevice(wires=4, token=MQSS_TOKEN, backends=MQSS_BACKENDS)
 dev_simulator = qml.device("default.qubit", wires=2)
-dev_hamiltonian = MQSSPennylaneDevice(wires=2, token=MQSS_TOKEN, backends=MQSS_BACKENDS)
+dev_hamiltonian = MQSSPennylaneDevice(wires=2, token=MQSS_TOKEN, backends=MQSS_BACKENDS, use_commuting_measurement_grouping=False)
 dev_hamiltonian_simulator = qml.device("default.qubit", wires=2)
+dev_hamiltonian_grouping = MQSSPennylaneDevice(wires=2, token=MQSS_TOKEN, backends=MQSS_BACKENDS, use_commuting_measurement_grouping=True)
 
 dev_autograd = MQSSPennylaneDevice(wires=2, token=MQSS_TOKEN, backends=MQSS_BACKENDS)
 dev_probs = MQSSPennylaneDevice(wires=2, token=MQSS_TOKEN, backends=MQSS_BACKENDS)
@@ -121,6 +122,24 @@ def quantum_function_hamiltonian_expval(
 
     return qml.expval(H)
 
+@qml.qnode(dev_hamiltonian_grouping)
+def quantum_function_hamiltonian_expval_grouping(
+    x: float, y: float, H: qml.Hamiltonian
+) -> float:
+    """
+    The function `quantum_function_hamiltonian_expval_grouping` applies quantum operations RZ, CNOT, and RY to qubits and returns
+    the expectation value of a given Hamiltonian on the second qubit, using commuting measurement grouping.
+
+    :param x: The parameter `x` in the `quantum_function_expval` represents the angle for the rotation gate
+    `RZ` applied on the qubit at wire 0
+    :param y: The parameter `y` in the `quantum_function_expval` function is used as the angle parameter for
+    the rotation gate `RY(y, wires=1)`. This gate applies a rotation around the y-axis of the Bloch
+    sphere by an angle `y` to the qubit on wire
+    :return: The function `quantum_function_expval` returns the expected value of a given operator
+    :H: Pennylane Hamiltonian object
+    """
+    arbitrary_quantum_circuit(x, y)
+    return qml.expval(H)
 
 @qml.qnode(dev_hamiltonian_simulator)
 def quantum_function_hamiltonian_expval_simulator(
@@ -207,6 +226,35 @@ class TestPennylaneLiveJobs(TestPennylaneAdapter):
 
         try:
             result = quantum_function_hamiltonian_expval(*params, hamiltonian)
+            result_simulator = quantum_function_hamiltonian_expval_simulator(
+                *params, hamiltonian
+            )
+
+        except Exception as e:
+            print(
+                f"There was an error while measuring the expectation value of the hamiltonian, with the following error: {e}"
+            )
+            raise e
+
+        assert result is not None
+        assert abs(result - result_simulator) <= 3e-1
+
+    def test_hamiltonian_measurements_grouping(
+        self,
+        hamiltonian_data: tuple[list[float], list[qml.ops.qubit.non_parametric_ops]],
+        params: list[float],
+    ):
+        """Run a quantum circuit with a hamiltonian expectation value, using commuting measurement grouping
+
+        Args:
+            coeffs (list[float]): _description_
+            obs (list[qml.ops.qubit.non_parametric_ops]): _description_
+        """
+        coeffs, obs = hamiltonian_data
+        hamiltonian = qml.Hamiltonian(coeffs, obs)
+
+        try:
+            result = quantum_function_hamiltonian_expval_grouping(*params, hamiltonian)
             result_simulator = quantum_function_hamiltonian_expval_simulator(
                 *params, hamiltonian
             )


### PR DESCRIPTION
Fixes https://github.com/Munich-Quantum-Software-Stack/MQSS-Pennylane-Adapter/issues/32

- Updated `MQSSPennylaneDevice` to identify Hamiltonian expectation-value measurements separately from simple expectation values.
- Added support for grouping commuting Pauli terms using `qml.pauli.group_observables(..., grouping_type="qwc")` from [Pennylane](https://docs.pennylane.ai/en/stable/code/api/pennylane.pauli.group_observables.html).
- Builds one batched circuit per commuting group and appends the required basis-change measurement gates.
Ensures the device still supports non-grouped Hamiltonian measurement execution when grouping is disabled by using `use_commuting_measurement_grouping` flag. 
```python
dev_hamiltonian_grouping = MQSSPennylaneDevice(wires, token, backends, use_commuting_measurement_grouping=True)
```
- Added live test coverage