### PR TITLE
feat(core): allow jobs with autograd/param-shift method

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mqss-pennylane-adapter"
-version = "1.2.1"
+version = "1.2.1b1"
 description = "A Pennylane Adapter package for the Munich Quantum Software Stack."
 authors = [{ name = "mqss", email = "mqss@munich-quantum-valley.de" }]
 readme = "README.md"

--- a/src/mqss/pennylane_adapter/device.py
+++ b/src/mqss/pennylane_adapter/device.py
@@ -115,16 +115,37 @@ class MQSSPennylaneDevice(Device):
         Returns:
             TensorLike: Measurement results
         """
+        if isinstance(circuits, (list, tuple)):
+            results = [
+                self._execute_single_circuit(circuit, execution_config)
+                for circuit in circuits
+            ]
+            return results[0] if len(results) == 1 else tuple(results)
+
+        return self._execute_single_circuit(circuits, execution_config)
+
+    def _execute_single_circuit(
+        self,
+        circuit: QuantumScriptOrBatch,
+        execution_config: ExecutionConfig,
+    ) -> TensorLike:
+        """Sends a single Pennylane circuit to the specified MQSS backend.
+
+        Args:
+            circuit (QuantumScriptOrBatch): Pennylane circuit
+            execution_config (ExecutionConfig): Additional config for the circuit if necessary
+
+        Returns:
+            TensorLike: Measurement results
+        """
+
         shots = (
-            circuits[0].shots.total_shots
-            if circuits[0].shots.total_shots is not None
+            circuit.shots.total_shots
+            if circuit.shots.total_shots is not None
             else self._legacy_shots
         )
         self.batch_circuits = False
-        if isinstance(circuits, list):
-            self.batch_circuits = True
 
-        circuit = circuits[0]
         self.measurement_type = self.determine_measurement_type(circuit)
         adapter = MQSSPennylaneAdapter(token=self.TOKEN, url=MQSS_URL)
         backend = adapter.get_backend(self.BACKENDS)

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -3,6 +3,11 @@ import pennylane as qml
 from pennylane import numpy as np
 
 
+@pytest.fixture(params=[np.array([0.1, 0.2], requires_grad=True)])
+def grad_params(request):
+    return request.param
+
+
 @pytest.fixture(
     params=[
         [np.pi / 5, np.pi],

--- a/test/test_backend.py
+++ b/test/test_backend.py
@@ -225,7 +225,7 @@ class TestPennylaneJobs(TestPennylaneAdapter):
         )
 
     @pytest.mark.parametrize("params", [[np.pi / 5, np.pi]])
-    def _test_autograd(params: list[float]) -> bool:
+    def test_autograd(monkeypatch: pytest.MonkeyPatch, params: list[float]) -> bool:
         """Compare the runs done on LRZ backend with ideal simulations in d
 
         Args:
@@ -234,12 +234,33 @@ class TestPennylaneJobs(TestPennylaneAdapter):
 
         """
 
-        results = qml.gradients.param_shift(quantum_function_autograd)(*params)
-        print(results)
-        assert (
-            quantum_function_expval.qtape.operations
-            == quantum_function_expval_simulator.qtape.operations
+        dev_autograd = MQSSPennylaneDevice(
+            wires=2, token=MQSS_TOKEN, backends=MQSS_BACKENDS
         )
+
+        @qml.qnode(
+            dev_autograd,
+            interface="autograd",
+            diff_method="parameter-shift",
+            shots=1024,
+        )
+        def quantum_function_autograd(x, y):
+            qml.RZ(x, wires=0)
+            qml.H(wires=0)
+            qml.CNOT(wires=[0, 1])
+            qml.H(wires=1)
+            qml.RY(y, wires=1)
+            qml.CNOT(wires=[1, 0])
+            qml.H(wires=1)
+            qml.RX(x, wires=1)
+            return qml.expval(qml.PauliX(0) @ qml.PauliZ(1))
+
+        params = np.array([0.1, 0.2], requires_grad=True)
+
+        results = qml.gradients.param_shift(quantum_function_autograd)(
+            params[0], params[1]
+        )
+        assert results is not None
 
     @pytest.mark.parametrize("coeffs", [[1.5, -0.92]])
     @pytest.mark.parametrize(

--- a/test/test_backend_live.py
+++ b/test/test_backend_live.py
@@ -163,8 +163,7 @@ class TestPennylaneLiveJobs(TestPennylaneAdapter):
         ).resources
         assert resources.depth == simulator_resources.depth
 
-    @pytest.mark.parametrize("params", [[np.pi / 5, np.pi]])
-    def _test_autograd(self, params: list[float]) -> bool:
+    def _test_autograd(self, grad_params: list[float]) -> bool:
         """Compare the runs done on MQSS backend with ideal simulations in terms of autograd support
 
         Args:
@@ -173,12 +172,8 @@ class TestPennylaneLiveJobs(TestPennylaneAdapter):
 
         """
 
-        results = qml.gradients.param_shift(quantum_function_autograd)(*params)
+        results = qml.gradients.param_shift(quantum_function_autograd)(*grad_params)
         assert results is not None
-        assert (
-            quantum_function_expval.qtape.operations
-            == quantum_function_expval_simulator.qtape.operations
-        )
 
     def test_expectation_value_measurements(
         self, obs: qml.ops.qubit.non_parametric_ops, params: list[float]


### PR DESCRIPTION
Fixes #31 
This hotfix enables using `autograd` and `param-shift `methods for circuits with trainable parameters, such as: 

```
 dev_autograd = MQSSPennylaneDevice(
            wires=2, token=MQSS_TOKEN, backends=MQSS_BACKENDS
        )

        @qml.qnode(
            dev_autograd,
            interface="autograd",
            diff_method="parameter-shift",
            shots=1024,
        )
        def quantum_function_autograd(x, y):
            qml.H(wires=0)
            qml.RZ(x, wires=0)
            qml.CNOT(wires=[0, 1])
            qml.RY(y, wires=1)
            qml.CNOT(wires=[1, 0])
            qml.RX(x, wires=1)
            return qml.expval(qml.PauliX(0) @ qml.PauliZ(1))

        params = np.array([0.1, 0.2], requires_grad=True)

        results = qml.gradients.param_shift(quantum_function_autograd)(
            params[0], params[1]
        )
```

The reason why this feature was not supported before, was simply the execute method in `device.py` did not allow automatic batching, if not specified exclusively. However, param-shift method requires the circuit to be modified and executed multiple times, with perturbated parameter values. 

https://github.com/Munich-Quantum-Software-Stack/MQSS-Pennylane-Adapter/blob/6e6ada7980a94e484e6d09cf01402c2da14f7129/src/mqss/pennylane_adapter/device.py#L127

This PR implements a mechanism where a `QTape` object is being checked if it is in a batched form, then calls the execute method for individual circuits. 