### PR TITLE
feat(mock): Extend mock results

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -5,9 +5,8 @@ from pennylane import numpy as np
 
 @pytest.fixture(
     params=[
-        [np.pi / 5, np.pi],
-        # [np.pi / 3, np.pi / 17],
-        # [np.pi * 13 / 12, np.pi / 8],
+        [2 * np.pi / 7, np.pi/8],
+        [0,0],
     ]
 )
 def params(request):
@@ -34,10 +33,10 @@ def obs(request):
                 qml.PauliY(0) @ qml.PauliZ(1),
             ],
         ),
-        # (
-        #     [1.5],
-        #     [qml.PauliZ(0) @ qml.PauliX(1)],
-        # ),
+        (
+            [1.5],
+            [qml.PauliZ(0) @ qml.PauliX(1)],
+        ),
         # (
         #     [1.5],
         #     [qml.PauliZ(0)],
@@ -46,14 +45,14 @@ def obs(request):
         #     [1.2, 0.3],
         #     [qml.PauliX(0) @ qml.PauliX(1), qml.PauliX(0)],
         # ),
-        # (
-        #     [-0.5, -0.2, -0.2],
-        #     [
-        #         qml.PauliZ(0) @ qml.PauliZ(1),
-        #         qml.PauliX(0),
-        #         qml.PauliX(1),
-        #     ],
-        # ),
+        (
+            [0.8, -0.2, -0.2],
+            [
+                qml.PauliZ(0) @ qml.PauliZ(1),
+                qml.PauliX(0),
+                qml.PauliX(1),
+            ],
+        ),
     ]
 )
 def hamiltonian_data(request):

--- a/test/mocks.py
+++ b/test/mocks.py
@@ -10,7 +10,7 @@ MOCK_RESOURCES = {
 }
 
 MOCK_JOB_DATA = {
-    "normal": {# For resource endpoints
+    "normal": {  # For resource endpoints
         "resources": MOCK_RESOURCES,
         "resources/Q5": CURRENT_RESOURCES["Q5"].__dict__,
         "resources/Q5/num_pending_jobs": {"num_pending_jobs": 3},
@@ -32,46 +32,147 @@ MOCK_JOB_DATA = {
             "timestamp_completed": "2023-04-14 10:15:30.123456",
             "timestamp_submitted": "2023-04-14 10:00:00.123456",
             "timestamp_scheduled": "2023-04-14 10:05:00.123456",
-        }
-
-
         },
+    },
     "hamiltonian": {
-             "resources": MOCK_RESOURCES,
-                "resources/Q5": CURRENT_RESOURCES["MAQCS"].__dict__,
-                "resources/Q5/num_pending_jobs": {"num_pending_jobs": 3},
-                # For job endpoints
-                "job": {"jobs": ["mock-uuid-12345"]},
-                "hamiltonian_job": {"jobs": ["mock-uuid-12345"]},
-                # Status endpoints
-                "job/mock-uuid-12345/status": {"status": "COMPLETED"},
-                "hamiltonian_job/mock-uuid-12345/status": {"status": "COMPLETED"},
-                # Result endpoints
-                "job/mock-uuid-12345/result": {
-                    'result': '[{"00": 3, "01": 85, "11": 936}, {"00": 40, "01": 44, "10": 501, "11": 439}]', 
-                    'timestamp_completed': '2026-08-24 11:54:49.593776', 
-                    'timestamp_scheduled': '2026-08-24 11:52:10.840863', 
-                    'timestamp_submitted': '2026-08-24 11:52:07.858568'
-                },
-                "hamiltonian_job/mock-uuid-12345/result": {
-                    'result': '[{"00": 3, "01": 85, "11": 936}, {"00": 40, "01": 44, "10": 501, "11": 439}]', 
-                    'timestamp_completed': '2026-08-24 11:54:49.593776', 
-                    'timestamp_scheduled': '2026-08-24 11:52:10.840863', 
-                    'timestamp_submitted': '2026-08-24 11:52:07.858568'
-                }
-    }
-    
+        "resources": MOCK_RESOURCES,
+        "resources/Q5": CURRENT_RESOURCES["MAQCS"].__dict__,
+        "resources/Q5/num_pending_jobs": {"num_pending_jobs": 3},
+        # For job endpoints
+        "job": {"jobs": ["mock-uuid-12345"]},
+        "hamiltonian_job": {"jobs": ["mock-uuid-12345"]},
+        # Status endpoints
+        "job/mock-uuid-12345/status": {"status": "COMPLETED"},
+        "hamiltonian_job/mock-uuid-12345/status": {"status": "COMPLETED"},
+        # Result endpoints
+        "job/mock-uuid-12345/result": {
+            "result": '[{"00": 3, "01": 85, "11": 936}, {"00": 40, "01": 44, "10": 501, "11": 439}]',
+            "timestamp_completed": "2026-08-24 11:54:49.593776",
+            "timestamp_scheduled": "2026-08-24 11:52:10.840863",
+            "timestamp_submitted": "2026-08-24 11:52:07.858568",
+        },
+        "hamiltonian_job/mock-uuid-12345/result": {
+            "result": '[{"00": 3, "01": 85, "11": 936}, {"00": 40, "01": 44, "10": 501, "11": 439}]',
+            "timestamp_completed": "2026-08-24 11:54:49.593776",
+            "timestamp_scheduled": "2026-08-24 11:52:10.840863",
+            "timestamp_submitted": "2026-08-24 11:52:07.858568",
+        },
+    },
 }
 
 
-'''
-Result JSON: 
-{'result': '[{"00": 3, "01": 85, "11": 936}, {"00": 40, "01": 44, "10": 501, "11": 439}]', 
-'timestamp_completed': '2026-08-24 11:54:49.593776', 
-'timestamp_scheduled': '2026-08-24 11:52:10.840863', 
-'timestamp_submitted': '2026-08-24 11:52:07.858568'}
+MOCK_RESULTS = {
+    "test_compare_generated_circuits[params0]": {
+        "result": '[{"00": 277, "01": 236, "10": 241, "11": 270}]',
+        "timestamp_completed": "2026-08-24 20:47:46.308632",
+        "timestamp_scheduled": "2026-08-24 20:46:18.527586",
+        "timestamp_submitted": "2026-08-24 20:46:15.905337",
+    },
+    "test_counts_single_wire[params0]": {
+        "result": '[{"01": 86, "11": 938}]',
+        "timestamp_completed": "2026-08-24 20:49:18.584341",
+        "timestamp_scheduled": "2026-08-24 20:47:52.364818",
+        "timestamp_submitted": "2026-08-24 20:47:49.735804",
+    },
+    "test_counts_all_wires[params0]": {
+        "result": '[{"00": 3, "01": 99, "11": 922}]',
+        "timestamp_completed": "2026-08-24 20:50:42.609569",
+        "timestamp_scheduled": "2026-08-24 20:49:19.637926",
+        "timestamp_submitted": "2026-08-24 20:49:19.186776",
+    },
+    "test_counts_all_outcomes": {
+        "result": '[{"00": 1021, "10": 1, "11": 2}]',
+        "timestamp_completed": "2026-08-24 20:52:09.944271",
+        "timestamp_scheduled": "2026-08-24 20:50:46.664719",
+        "timestamp_submitted": "2026-08-24 20:50:44.554766",
+    },
+    "test_counts_matches_simulator[params0]": {
+        "result": '[{"00": 804, "01": 9, "10": 193, "11": 18}]',
+        "timestamp_completed": "2026-08-24 20:53:39.054322",
+        "timestamp_scheduled": "2026-08-24 20:52:13.876448",
+        "timestamp_submitted": "2026-08-24 20:52:10.891891",
+    },
+    "test_counts_matches_simulator[params1]": {
+        "result": '[{"00": 1018, "01": 2, "11": 4}]',
+        "timestamp_completed": "2026-08-24 20:55:06.881543",
+        "timestamp_scheduled": "2026-08-24 20:53:44.422734",
+        "timestamp_submitted": "2026-08-24 20:53:41.148439",
+    },
+    "test_expectation_value_measurements[obs0-params0]": {
+        "result": '[{"00": 467, "01": 39, "10": 493, "11": 25}]',
+        "timestamp_completed": "2026-08-24 20:56:31.633212",
+        "timestamp_scheduled": "2026-08-24 20:55:11.593282",
+        "timestamp_submitted": "2026-08-24 20:55:08.436907",
+    },
+    "test_expectation_value_measurements[obs0-params1]": {
+        "result": '[{"00": 518, "01": 2, "10": 504}]',
+        "timestamp_completed": "2026-08-24 20:57:55.452667",
+        "timestamp_scheduled": "2026-08-24 20:56:35.665531",
+        "timestamp_submitted": "2026-08-24 20:56:33.411548",
+    },
+    "test_expectation_value_measurements[obs1-params0]": {
+        "result": '[{"00": 800, "01": 1, "10": 183, "11": 40}]',
+        "timestamp_completed": "2026-08-24 20:59:24.119698",
+        "timestamp_scheduled": "2026-08-24 20:57:59.906564",
+        "timestamp_submitted": "2026-08-24 20:57:58.428469",
+    },
+    "test_expectation_value_measurements[obs1-params1]": {
+        "result": '[{"00": 1022, "10": 2}]',
+        "timestamp_completed": "2026-08-24 21:08:49.577835",
+        "timestamp_scheduled": "2026-08-24 21:07:18.625465",
+        "timestamp_submitted": "2026-08-24 21:07:16.820790",
+    },
+    "test_hamiltonian_measurements[hamiltonian_data0-params1]": {
+        "result": '[{"00": 1017, "01": 2, "10": 2, "11": 3}, {"00": 516, "01": 506, "11": 2}]',
+        "timestamp_completed": "2026-08-24 22:15:44.694427",
+        "timestamp_scheduled": "2026-08-24 22:12:48.998477",
+        "timestamp_submitted": "2026-08-24 22:12:48.554165",
+    },
+    "test_hamiltonian_measurements[hamiltonian_data1-params0]": {
+        "result": '[{"00": 470, "01": 14, "10": 530, "11": 10}]',
+        "timestamp_completed": "2026-08-24 22:17:42.645021",
+        "timestamp_scheduled": "2026-08-24 22:16:14.857459",
+        "timestamp_submitted": "2026-08-24 22:16:12.044152",
+    },
+    "test_hamiltonian_measurements[hamiltonian_data1-params1]": {
+        "result": '[{"00": 513, "10": 511}]',
+        "timestamp_completed": "2026-08-24 22:19:13.353910",
+        "timestamp_scheduled": "2026-08-24 22:17:48.232685",
+        "timestamp_submitted": "2026-08-24 22:17:45.562559",
+    },
+    "test_hamiltonian_measurements[hamiltonian_data2-params0]": {
+        "result": '[{"00": 793, "01": 7, "10": 199, "11": 25}, {"00": 377, "01": 137, "10": 159, "11": 351}]',
+        "timestamp_completed": "2026-08-24 22:25:41.682810",
+        "timestamp_scheduled": "2026-08-24 22:22:47.275222",
+        "timestamp_submitted": "2026-08-24 22:22:46.590544",
+    },
+    "test_hamiltonian_measurements[hamiltonian_data2-params1]": {
+        "result": '[{"00": 1023, "11": 1}, {"00": 297, "01": 224, "10": 225, "11": 278}]',
+        "timestamp_completed": "2026-08-24 22:28:44.018090",
+        "timestamp_scheduled": "2026-08-24 22:25:47.341915",
+        "timestamp_submitted": "2026-08-24 22:25:44.143619",
+    },
+    "test_probs[params0]": {
+            "result": '[{"00": 810, "01": 5, "10": 181, "11": 28}]',
+            "timestamp_completed": "2026-08-24 22:28:44.018090",
+            "timestamp_scheduled": "2026-08-24 22:25:47.341915",
+            "timestamp_submitted": "2026-08-24 22:25:44.143619",
+        },
+    "test_probs[params1]": {
+                "result": '[{"00": 1020, "01": 4}]',
+                "timestamp_completed": "2026-08-24 22:28:44.018090",
+                "timestamp_scheduled": "2026-08-24 22:25:47.341915",
+                "timestamp_submitted": "2026-08-24 22:25:44.143619",
+            },
+    "test_multiple_expvals[list_obs0-params0]": {
+                    'result': '[{"0000": 777, "0001": 3, "0010": 209, "0011": 35}, {"0000": 472, "0001": 24, "0010": 493, "0011": 31, "1000": 4}, {"0000": 806, "0001": 5, "0010": 192, "0011": 21}, {"0000": 815, "0001": 12, "0010": 177, "0011": 19, "1000": 1}]',
+                    "timestamp_completed": "2026-08-24 22:28:44.018090",
+                    "timestamp_scheduled": "2026-08-24 22:25:47.341915",
+                    "timestamp_submitted": "2026-08-24 22:25:44.143619",
+                },
+}
 
-'''
+
 
 # =================== REST CLIENT MOCKS ===================
 def create_rest_mock():

--- a/test/test_backend.py
+++ b/test/test_backend.py
@@ -12,7 +12,7 @@ from pennylane import numpy as np
 from src.mqss.pennylane_adapter.config import MQSS_BACKENDS, MQSS_TOKEN
 from src.mqss.pennylane_adapter.device import MQSSPennylaneDevice
 
-from .mocks import MOCK_JOB_DATA
+from .mocks import MOCK_JOB_DATA, MOCK_RESULTS
 from .pennylane_adapter_tests_base import TestPennylaneAdapter
 
 dev = MQSSPennylaneDevice(wires=2, token=MQSS_TOKEN, backends=MQSS_BACKENDS)
@@ -169,6 +169,7 @@ class TestPennylaneJobs(TestPennylaneAdapter):
     def patch_job_result(self, monkeypatch, request):
 
         test_name = request.function.__name__
+        node_id = request.node.name  # includes the parametrize suffix, e.g. "[params1]"
 
         test_types = {
             "test_compare_runs": "normal",
@@ -184,12 +185,15 @@ class TestPennylaneJobs(TestPennylaneAdapter):
             "test_compare_generated_circuits": "normal",
         }
         test_type = test_types.get(test_name, "normal")
-    
+
         def mock_job_result(self, uuid, job_type):
 
-            # Just always return the MOCK_JOB_DATA for the fixed UUID and job type key
+            # Prefer a result captured for this exact parametrization; fall
+            # back to the generic per-test-type default otherwise.
             key = f"job/{uuid}/result"  # or hardcode if you want
-            result_json = MOCK_JOB_DATA[test_type].get(key)
+            default_result_json = MOCK_JOB_DATA[test_type].get(key)
+            result_json = MOCK_RESULTS.get(node_id, default_result_json)
+            
             # Construct Result without any checks
             return Result(
                 counts=json.loads(result_json["result"]),
@@ -245,8 +249,8 @@ class TestPennylaneJobs(TestPennylaneAdapter):
         result = quantum_function_counts(*params, wires=[0])
         assert result is not None
         assert all(len(key) == 1 for key in result)
-        
-        assert sum(result.values()) == 1000
+
+        assert sum(result.values()) == 1024
  
     @pytest.mark.parametrize("params", [[np.pi / 5, np.pi]])
     def test_counts_all_wires(self, params: list[float]) -> None:
@@ -261,7 +265,7 @@ class TestPennylaneJobs(TestPennylaneAdapter):
         assert result is not None
         assert all(len(key) == 2 for key in result)
 
-        assert sum(result.values()) == 1000
+        assert sum(result.values()) == 1024
  
     def test_counts_all_outcomes(self) -> None:
         """With all_outcomes=True, every possible bitstring for the requested
@@ -271,7 +275,7 @@ class TestPennylaneJobs(TestPennylaneAdapter):
         result = quantum_function_counts(0.0, 0.0, wires=[0], all_outcomes=True)
         assert set(result.keys()) == {"0", "1"}
  
-    def _test_compare_generated_circuits(self, params: list[float]) -> bool:
+    def test_compare_generated_circuits(self, params: list[float]) -> bool:
         """Compare the runs done on LRZ backend with ideal simulations.
  
         Args:
@@ -283,12 +287,12 @@ class TestPennylaneJobs(TestPennylaneAdapter):
         _ = quantum_function_expval(*params)
  
         assert (
-            quantum_function_expval.qtape.operations
-            == quantum_function_expval_simulator.qtape.operations
+            quantum_function_expval._tape.operations
+            == quantum_function_expval_simulator._tape.operations
         )
 
-    @pytest.mark.parametrize("params", [[np.pi / 5, np.pi]])
-    def _test_autograd(params: list[float]) -> bool:
+    
+    def _test_autograd(self, params: list[float]) -> bool:
         """Compare the runs done on LRZ backend with ideal simulations in d
 
         Args:
@@ -299,8 +303,8 @@ class TestPennylaneJobs(TestPennylaneAdapter):
 
         _ = qml.gradients.param_shift(quantum_function_autograd)(*params)
         assert (
-            quantum_function_expval.qtape.operations
-            == quantum_function_expval_simulator.qtape.operations
+            quantum_function_expval._tape.operations
+            == quantum_function_expval_simulator._tape.operations
         )
 
    

--- a/test/test_backend_live.py
+++ b/test/test_backend_live.py
@@ -259,7 +259,7 @@ class TestPennylaneLiveJobs(TestPennylaneAdapter):
         assert sum(result.values()) == dev_counts._legacy_shots
 
     def _test_counts_matches_simulator(self, params: list[float]):
-        """Compare the empirical distribution of counts from the MQSS backend
+        """Compare the distribution of counts from the MQSS backend
         against the Pennylane simulator."""
         x, y = params
         result = quantum_function_counts(x, y)
@@ -314,9 +314,9 @@ class TestPennylaneLiveJobs(TestPennylaneAdapter):
             raise
 
         assert result is not None
-        assert abs(result - result_simulator) <= 3e-1
+        assert abs(result - result_simulator) <= 4e-1
 
-    def _test_probs(self, params: list[float]):
+    def test_probs(self, params: list[float]):
         """Test that we can get probabilities back from the device"""
         x, y = params
         result = quantum_function_probs(x, y)
@@ -326,7 +326,7 @@ class TestPennylaneLiveJobs(TestPennylaneAdapter):
         assert abs(sum(result) - 1) <= 1e-6
         assert all(0 <= p <= 1 for p in result)
 
-    def _test_multiple_expvals(
+    def test_multiple_expvals(
         self, list_obs: list[qml.ops.qubit.non_parametric_ops], params: list[float]
     ):
         """Test that we can get multiple expectation values back from the device"""


### PR DESCRIPTION
Extended mock results for different unit test types per measurement types (i.e. separate results for expectation values, counts, probs etc.)